### PR TITLE
Fix .get when containing falsy values

### DIFF
--- a/kv.js
+++ b/kv.js
@@ -108,7 +108,7 @@ class kvjs {
         if (isExpired) {
             return null;
         }
-        return this.store.get(key) || null;
+        return this.store.get(key) ?? null;
     }
 
     /**


### PR DESCRIPTION
If the value is falsy (false, null, 0, "", etc), null would be returned instead. This changes makes it possible to retrieve those values.