### PR TITLE
fix: don't hang process due to cleanup interval

### DIFF
--- a/kv.js
+++ b/kv.js
@@ -2924,6 +2924,7 @@ class kvjs {
                     }
                 }
             }, cleanupIntervalMs);
+            this.cleanupLoop.unref();
         }
     }
 


### PR DESCRIPTION
When a value is set in kv.js the cleanup loop is triggered by the _initCleanupLoop method on an instance of the kvjs class. This cleanup loop is created with `setInterval` and hangs the process.

Fortunately, node.js has a `.unref()` method on interval timers which allows us to tell node.js that we don't want this interval to keep the process alive.

This fix is necessary for unit-testing any code that uses kv.js, otherwise the test process hangs indefinitely and the unit testing framework is not even able to catch this issue.