### PR TITLE
chore: update package-lock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heyputer/kv.js",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@heyputer/kv.js",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^9.0.0"


### PR DESCRIPTION
The package-lock.json version doesn't match the package.json version, causing package-lock.json to be modified after running `npm install`.