### PR TITLE
Fix "XMap is not defined" when bundling

### DIFF
--- a/XMap.js
+++ b/XMap.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Class representing an extended version of the Map class that supports storing more than
  * 16,777,215 keys by using multiple Map instances internally. This class provides a unified

--- a/kv.js
+++ b/kv.js
@@ -1,5 +1,7 @@
+'use strict';
+
 const {minimatch} = require('minimatch');
-XMap = require('./XMap');
+const XMap = require('./XMap.js');
 
 // The cleanup loop runs as long as there's at least one key set, and will
 // regularly check for expired keys and remove them from the store.


### PR DESCRIPTION
We are experiencing an issue when bundling `kv.js` as a dependency in a SvelteKit application. The problem seem to be caused by the fact that symbol `XMap` is assigned before being declared either with `let` or `const`. Adding `'use strict';` at the beginning of file causes the same error to be raised when running `npm run test` in this project. Just adding `const` solves the issue, and as far as I can see should have no negative side effects.